### PR TITLE
Fix Yarn check...

### DIFF
--- a/yarn-wrapper
+++ b/yarn-wrapper
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 echo -n "Checking JS modules... "
-if $(yarn check &> /dev/null); then
+
+if yarn check --integrity --verify-tree --silent; then
   echo "OK 👍"
 else
   echo "failed! 💥"


### PR DESCRIPTION
... to be faster and not do any network connection 💨 

Apparently, the [documentation for `yarn check`](https://yarnpkg.com/en/docs/cli/check) is quite misleading and incomplete, according to [many](https://github.com/yarnpkg/yarn/issues/674) [people](https://github.com/yarnpkg/yarn/issues/2890):  `yarn check` without argument seems to be doing a lot more than just checking if required modules are installed (as `bundle check` does).

The correct command line to do what we expect here is `yarn check --integrity --verify-tree`.

There's also a `--check-files` option available, but it seems to do the same thing as `--verify-tree`, from what I can see (but it's still unclear because both are totally undocumented and I have no wish at all to dive head first into Yarn source code).

Anyway, this PR should speed up all commands run with `docker-compose run frontend ...` as shown by this very basic benchmark:

```
# Before this PR
→ time docker-compose run frontend true
Checking bundle... OK 👍
Checking JS modules... OK 👍
real    0m24.058s
user    0m1.299s
sys     0m0.269s

# After this PR
→ time docker-compose run frontend true
Checking bundle... OK 👍
Checking JS modules... OK 👍
real    0m4.749s
user    0m1.355s
sys     0m0.297s
```