### PR TITLE
Use a 'check' script if it is defined in package.json…

### DIFF
--- a/yarn-wrapper
+++ b/yarn-wrapper
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-echo -n "Checking JS modules... "
+check_command=$(yarn run 2> /dev/null | grep -qx '^\s\+-\s\+check$' && echo "yarn run check" || echo "yarn check --integrity --verify-tree")
 
-if yarn check --integrity --verify-tree --silent; then
+echo -n "Checking JS modules... "
+if eval $check_command --silent; then
   echo "OK 👍"
 else
   echo "failed! 💥"
   echo "Updating JS modules..."
-  yarn install
+  yarn install --check-files
 fi
 
 exec "$@"

--- a/yarn-wrapper
+++ b/yarn-wrapper
@@ -3,7 +3,7 @@
 check_command=$(yarn run 2> /dev/null | grep -qx '^\s\+-\s\+check$' && echo "yarn run check" || echo "yarn check --integrity --verify-tree")
 
 echo -n "Checking JS modules... "
-if eval $check_command --silent; then
+if eval $check_command --silent 2> /dev/null; then
   echo "OK 👍"
 else
   echo "failed! 💥"


### PR DESCRIPTION
…and make 'yarn install' check for missing or corrupted files.

[Trello card](https://trello.com/c/1sBtYJba/1444-dev-fix-yarn-check-and-yarn-install-in-yarn-wrapper)

## Description

This PR does not just run `yarn check` in project root, it uses `yarn run check` if a script named `check` exists in `package.json` (which allows applications to define custom check scripts, like for recursive directories) but still falls back to using `yarn check` if no such custom script has been defined.

## How to test

0. Build the Docker image: `docker build -t kyero/ruby-node .`
1. Brutally delete a nested node module inside the container: `docker-compose run frontend rm -rf client/node_modules/babel-preset-react`
2. Make sure the container was not already existing: `docker-compose down`
3. Check that it is properly reinstalled when running the frontend: `docker-compose up frontend` (webpack compilation should then succeed)